### PR TITLE
Missing case: "/[]9999".succ should be "/[]10000"

### DIFF
--- a/core/string/shared/succ.rb
+++ b/core/string/shared/succ.rb
@@ -50,6 +50,7 @@ describe :string_succ, :shared => true do
     "9Z99z99Z".send(@method).should == "10A00a00A"
 
     "ZZZ9999".send(@method).should == "AAAA0000"
+    "/[]9999".send(@method).should == "/[]10000"
     "/[]ZZZ9999".send(@method).should == "/[]AAAA0000"
     "Z/[]ZZZ9999".send(@method).should == "AA/[]AAA0000"
 


### PR DESCRIPTION
I would have preferred to send this PR to [rubyspec/rubyspec](https://github.com/rubyspec/rubyspec), but that project is dead?