### PR TITLE
"('stuff'.equal? 'stuff').should == false" cannot be supported on Opal

### DIFF
--- a/core/kernel/equal_spec.rb
+++ b/core/kernel/equal_spec.rb
@@ -11,7 +11,9 @@ describe "Kernel#equal?" do
     (nil.equal? nil).should == true
     (o1.equal?  nil).should== false
     (nil.equal?  o2).should== false
-    ('stuff'.equal? 'stuff').should == false
+    not_supported_on :opal do
+      ('stuff'.equal? 'stuff').should == false
+    end
     (true.equal? true).should == true
     (false.equal? false).should == true
   end


### PR DESCRIPTION
Ref https://github.com/opal/opal/pull/730