### PR TITLE
Fix invalid regexp flag syntax errors on Firefox and IE

### DIFF
--- a/core/regexp/shared/equal_value.rb
+++ b/core/regexp/shared/equal_value.rb
@@ -4,12 +4,14 @@ describe :regexp_eql, :shared => true do
     /abc/.send(@method, /abd/).should == false
   end
 
-  it "is true if self and other have the same character set code" do
-    /abc/.send(@method, /abc/x).should == false
-    /abc/x.send(@method, /abc/x).should == true
-    /abc/u.send(@method, /abc/n).should == false
-    /abc/u.send(@method, /abc/u).should == true
-    /abc/n.send(@method, /abc/n).should == true
+  not_supported_on :opal do
+    it "is true if self and other have the same character set code" do
+      /abc/.send(@method, /abc/x).should == false
+      /abc/x.send(@method, /abc/x).should == true
+      /abc/u.send(@method, /abc/n).should == false
+      /abc/u.send(@method, /abc/u).should == true
+      /abc/n.send(@method, /abc/n).should == true
+    end
   end
 
   it "is true if other has the same #casefold? values" do
@@ -17,11 +19,13 @@ describe :regexp_eql, :shared => true do
     /abc/i.send(@method, /abc/i).should == true
   end
 
-  it "is true if self does not specify /n option and other does" do
-    //.send(@method, //n).should == true
-  end
+  not_supported_on :opal do
+    it "is true if self does not specify /n option and other does" do
+      //.send(@method, //n).should == true
+    end
 
-  it "is true if self specifies /n option and other does not" do
-    //n.send(@method, //).should == true
+    it "is true if self specifies /n option and other does not" do
+      //n.send(@method, //).should == true
+    end
   end
 end


### PR DESCRIPTION
Re issue https://github.com/opal/opal/issues/740