### PR TITLE
Regex Extended / Group Specific Flags Fixes

### DIFF
--- a/core/regexp/options_spec.rb
+++ b/core/regexp/options_spec.rb
@@ -3,7 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe "Regexp#options" do
   it "returns a Fixnum bitvector of regexp options for the Regexp object" do
     /cat/.options.should be_kind_of(Fixnum)
-    /cat/ix.options.should be_kind_of(Fixnum)
+    not_supported_on :opal do
+      /cat/ix.options.should be_kind_of(Fixnum)
+    end
   end
 
   it "allows checking for presence of a certain option with bitwise &" do
@@ -11,12 +13,14 @@ describe "Regexp#options" do
     (/cat/i.options & Regexp::IGNORECASE).should_not == 0
     (/cat/.options & Regexp::MULTILINE).should == 0
     (/cat/m.options & Regexp::MULTILINE).should_not == 0
-    (/cat/.options & Regexp::EXTENDED).should == 0
-    (/cat/x.options & Regexp::EXTENDED).should_not == 0
-    (/cat/mx.options & Regexp::MULTILINE).should_not == 0
-    (/cat/mx.options & Regexp::EXTENDED).should_not == 0
-    (/cat/xi.options & Regexp::IGNORECASE).should_not == 0
-    (/cat/xi.options & Regexp::EXTENDED).should_not == 0
+    not_supported_on :opal do
+      (/cat/.options & Regexp::EXTENDED).should == 0
+      (/cat/x.options & Regexp::EXTENDED).should_not == 0    
+      (/cat/mx.options & Regexp::MULTILINE).should_not == 0
+      (/cat/mx.options & Regexp::EXTENDED).should_not == 0
+      (/cat/xi.options & Regexp::IGNORECASE).should_not == 0
+      (/cat/xi.options & Regexp::EXTENDED).should_not == 0
+    end
   end
 
   it "raises a TypeError on an uninitialized Regexp" do

--- a/core/regexp/shared/new_ascii.rb
+++ b/core/regexp/shared/new_ascii.rb
@@ -35,36 +35,48 @@ describe :regexp_new_string_ascii, :shared => true do
     r = Regexp.send(@method, 'Hi')
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
   end
 
   it "does not set Regexp options if second argument is nil or false" do
     r = Regexp.send(@method, 'Hi', nil)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
 
     r = Regexp.send(@method, 'Hi', false)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
   end
 
   it "sets options from second argument if it is one of the Fixnum option constants" do
     r = Regexp.send(@method, 'Hi', Regexp::IGNORECASE)
     (r.options & Regexp::IGNORECASE).should_not == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
 
     r = Regexp.send(@method, 'Hi', Regexp::MULTILINE)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should_not  == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
 
-    r = Regexp.send(@method, 'Hi', Regexp::EXTENDED)
-    (r.options & Regexp::IGNORECASE).should     == 0
-    (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should_not   == 1
+    not_supported_on :opal do
+      r = Regexp.send(@method, 'Hi', Regexp::EXTENDED)
+      (r.options & Regexp::IGNORECASE).should     == 0
+      (r.options & Regexp::MULTILINE).should      == 0    
+      (r.options & Regexp::EXTENDED).should_not   == 1
+    end
   end
 
   it "accepts a Fixnum of two or more options ORed together as the second argument" do
@@ -78,7 +90,9 @@ describe :regexp_new_string_ascii, :shared => true do
     r = Regexp.send(@method, 'Hi', Object.new)
     (r.options & Regexp::IGNORECASE).should_not == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
   end
 
   it "ignores the third argument if it is 'e' or 'euc' (case-insensitive)" do
@@ -389,17 +403,23 @@ describe :regexp_new_regexp_ascii, :shared => true do
   it "preserves any options given in the Regexp literal" do
     (Regexp.send(@method, /Hi/i).options & Regexp::IGNORECASE).should_not == 0
     (Regexp.send(@method, /Hi/m).options & Regexp::MULTILINE).should_not == 0
-    (Regexp.send(@method, /Hi/x).options & Regexp::EXTENDED).should_not == 0
+    not_supported_on :opal do
+      (Regexp.send(@method, /Hi/x).options & Regexp::EXTENDED).should_not == 0
+    end
 
-    r = Regexp.send @method, /Hi/imx
-    (r.options & Regexp::IGNORECASE).should_not == 0
-    (r.options & Regexp::MULTILINE).should_not == 0
-    (r.options & Regexp::EXTENDED).should_not == 0
+    not_supported_on :opal do
+      r = Regexp.send @method, /Hi/imx
+      (r.options & Regexp::IGNORECASE).should_not == 0
+      (r.options & Regexp::MULTILINE).should_not == 0    
+      (r.options & Regexp::EXTENDED).should_not == 0
+    end
 
     r = Regexp.send @method, /Hi/
     (r.options & Regexp::IGNORECASE).should == 0
     (r.options & Regexp::MULTILINE).should == 0
-    (r.options & Regexp::EXTENDED).should == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should == 0
+    end
   end
 
   it "does not honour options given as additional arguments" do
@@ -424,6 +444,6 @@ describe :regexp_new_regexp_ascii, :shared => true do
   end
 
   it "sets the encoding to source String's encoding if the Regexp literal has the 'n' option and the source String is not ASCII only" do
-    Regexp.send(@method, /\xff/n).encoding.should == Encoding::ASCII_8BIT
+    Regexp.send(@method, Regexp.new("\\xff", nil, 'n')).encoding.should == Encoding::ASCII_8BIT
   end
 end

--- a/core/regexp/shared/new_ascii_8bit.rb
+++ b/core/regexp/shared/new_ascii_8bit.rb
@@ -37,36 +37,48 @@ describe :regexp_new_string_ascii_8bit, :shared => true do
     r = Regexp.send(@method, 'Hi')
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should       == 0
+    end
   end
 
   it "does not set Regexp options if second argument is nil or false" do
     r = Regexp.send(@method, 'Hi', nil)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should       == 0
+    end
 
     r = Regexp.send(@method, 'Hi', false)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should       == 0
+    end
   end
 
   it "sets options from second argument if it is one of the Fixnum option constants" do
     r = Regexp.send(@method, 'Hi', Regexp::IGNORECASE)
     (r.options & Regexp::IGNORECASE).should_not == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
 
     r = Regexp.send(@method, 'Hi', Regexp::MULTILINE)
     (r.options & Regexp::IGNORECASE).should     == 0
     (r.options & Regexp::MULTILINE).should_not  == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
 
-    r = Regexp.send(@method, 'Hi', Regexp::EXTENDED)
-    (r.options & Regexp::IGNORECASE).should     == 0
-    (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should_not   == 1
+    not_supported_on :opal do
+      r = Regexp.send(@method, 'Hi', Regexp::EXTENDED)
+      (r.options & Regexp::IGNORECASE).should     == 0
+      (r.options & Regexp::MULTILINE).should      == 0    
+      (r.options & Regexp::EXTENDED).should_not   == 1
+    end
   end
 
   it "accepts a Fixnum of two or more options ORed together as the second argument" do
@@ -80,7 +92,9 @@ describe :regexp_new_string_ascii_8bit, :shared => true do
     r = Regexp.send(@method, 'Hi', Object.new)
     (r.options & Regexp::IGNORECASE).should_not == 0
     (r.options & Regexp::MULTILINE).should      == 0
-    (r.options & Regexp::EXTENDED).should       == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should     == 0
+    end
   end
 
   it "ignores the third argument if it is 'e' or 'euc' (case-insensitive)" do
@@ -482,17 +496,23 @@ describe :regexp_new_regexp_ascii_8bit, :shared => true do
   it "preserves any options given in the Regexp literal" do
     (Regexp.send(@method, /Hi/i).options & Regexp::IGNORECASE).should_not == 0
     (Regexp.send(@method, /Hi/m).options & Regexp::MULTILINE).should_not == 0
-    (Regexp.send(@method, /Hi/x).options & Regexp::EXTENDED).should_not == 0
+    not_supported_on :opal do
+      (Regexp.send(@method, /Hi/x).options & Regexp::EXTENDED).should_not == 0
+    end
 
-    r = Regexp.send @method, /Hi/imx
-    (r.options & Regexp::IGNORECASE).should_not == 0
-    (r.options & Regexp::MULTILINE).should_not == 0
-    (r.options & Regexp::EXTENDED).should_not == 0
+    not_supported_on :opal do
+      r = Regexp.send @method, /Hi/imx
+      (r.options & Regexp::IGNORECASE).should_not == 0
+      (r.options & Regexp::MULTILINE).should_not == 0    
+      (r.options & Regexp::EXTENDED).should_not == 0
+    end
 
     r = Regexp.send @method, /Hi/
     (r.options & Regexp::IGNORECASE).should == 0
     (r.options & Regexp::MULTILINE).should == 0
-    (r.options & Regexp::EXTENDED).should == 0
+    not_supported_on :opal do
+      (r.options & Regexp::EXTENDED).should == 0
+    end
   end
 
   it "does not honour options given as additional arguments" do
@@ -517,6 +537,6 @@ describe :regexp_new_regexp_ascii_8bit, :shared => true do
   end
 
   it "sets the encoding to source String's encoding if the Regexp literal has the 'n' option and the source String is not ASCII only" do
-    Regexp.send(@method, /\xff/n).encoding.should == Encoding::ASCII_8BIT
+    Regexp.send(@method, Regexp.new("\\xff", nil, 'n')).encoding.should == Encoding::ASCII_8BIT
   end
 end

--- a/core/regexp/union_spec.rb
+++ b/core/regexp/union_spec.rb
@@ -10,7 +10,9 @@ describe "Regexp.union" do
   it "returns a regular expression that will match passed arguments" do
     Regexp.union("penzance").should == /penzance/
     Regexp.union("skiing", "sledding").should == /skiing|sledding/
-    Regexp.union(/dogs/, /cats/i).should == /(?-mix:dogs)|(?i-mx:cats)/
+    not_supported_on :opal do
+      Regexp.union(/dogs/, /cats/i).should == /(?-mix:dogs)|(?i-mx:cats)/
+    end
   end
 
   it "quotes any string arguments" do
@@ -139,7 +141,9 @@ describe "Regexp.union" do
 
   it "accepts a single array of patterns as arguments" do
     Regexp.union(["skiing", "sledding"]).should == /skiing|sledding/
-    Regexp.union([/dogs/, /cats/i]).should == /(?-mix:dogs)|(?i-mx:cats)/
+    not_supported_on :opal do
+      Regexp.union([/dogs/, /cats/i]).should == /(?-mix:dogs)|(?i-mx:cats)/
+    end
     lambda{Regexp.union(["skiing", "sledding"], [/dogs/, /cats/i])}.should raise_error(TypeError)
   end
 end


### PR DESCRIPTION
* Construct Regexs in shared/new as objects so that we can put the escape sequence in quotes, otherwise Opal can't even compile the file, much less ignore it
* Wrap flags unsupported by Javascript Regex (extended)
* In Javascript, RE's cannot override flags within a group, the flags apply to the entire expression, so these are not supported